### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/gfx/gl.rs
+++ b/src/gfx/gl.rs
@@ -5,8 +5,8 @@ include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 
 pub fn load(gl_context: &glutin::Context<PossiblyCurrent>) {
     load_with(|ptr| gl_context.get_proc_address(ptr) as *const _);
-    let version = unsafe {
-        let data = CStr::from_ptr(GetString(VERSION) as *const _).to_bytes().to_vec();
+    let version = {
+        let data = unsafe { CStr::from_ptr(GetString(VERSION) as *const _).to_bytes().to_vec() };
         String::from_utf8(data).unwrap()
     };
     let mut vao = 0;

--- a/src/gfx/mod.rs
+++ b/src/gfx/mod.rs
@@ -33,15 +33,15 @@ pub struct Buffer {
 
 impl Buffer {
     pub fn new(kind: BufferKind) -> Self {
-        unsafe {
+        
             let mut id = 0;
-            gl::GenBuffers(1, &mut id);
+            unsafe { gl::GenBuffers(1, &mut id) };
             Self {
                 id,
                 kind,
                 capacity: 0,
             }
-        }
+        
     }
 
     pub fn update<T: Copy>(&mut self, data: &[T]) {


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html