### PR TITLE
Add fontconfig support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ memmap2 = "0.2.1"
 glutin = "0.26.0"
 clipboard2 = "0.1.1"
 
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "android"))))'.dependencies]
+fontconfig-parser = "0.5"
+
 [build-dependencies]
 gl_generator = "0.14"

--- a/src/layout/font/types.rs
+++ b/src/layout/font/types.rs
@@ -74,7 +74,11 @@ pub enum FamilyKey<'a> {
 
 impl<'a> From<&'a str> for FamilyKey<'a> {
     fn from(name: &'a str) -> Self {
-        Self::Name(name)
+        if let Some(generic_family) = GenericFamily::parse(name) {
+            Self::Generic(generic_family)
+        } else {
+            Self::Name(name)
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds Fontconfig support for font related code.
It's using a [fontconfig-parser](https://lib.rs/crates/fontconfig-parser) written in Rust to read font_dir/alias configuration from file.

This should fix #2